### PR TITLE
Fix typo in META.yml

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -24,6 +24,6 @@ provides:
 requires:
   perl: '5.008000'
 resources:
-  bugtracker: https://github.com/daoswald/List/BinarySearch-XS/issues
+  bugtracker: https://github.com/daoswald/List-BinarySearch-XS/issues
   repository: https://github.com/daoswald/List-BinarySearch-XS.git
 version: '0.08'


### PR DESCRIPTION
The bugtracker field in META.yml used a / instead of a -, causing an incorrect link in metacpan.
